### PR TITLE
chip削除するためにごちゃごちゃしたので、整理できるようにブランチを分けて開発した

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="showProblemsInCodeBlocks" value="false" />
+  </component>
+</project>

--- a/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
@@ -15,7 +15,7 @@ import com.example.todoAppJpc.ui.todo.TodoEntryViewModel
 @Composable
 fun DatePickerComponent(
     viewModel: TodoEntryViewModel,
-    rememberDatePickerState: DatePickerState
+    rememberDatePickerState: DatePickerState,
 ) {
     Material3DatePickerDialogComponent(
         viewModel = viewModel,
@@ -35,7 +35,6 @@ fun Material3DatePickerDialogComponent(
     val datePickerStateSet = { viewModel.updateIsInputDatePickerState(true) }
     fun updateDatePickerState(selectedDateMillis: Long?) =
         viewModel.updateDatePickerState(selectedDateMillis)
-
 
     DatePickerDialog(
         onDismissRequest = {

--- a/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
@@ -3,6 +3,7 @@ package com.example.todoAppJpc.ui.components
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -10,12 +11,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.example.todoAppJpc.ui.todo.TodoEntryViewModel
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerComponent(
     viewModel: TodoEntryViewModel,
+    rememberDatePickerState: DatePickerState
 ) {
     Material3DatePickerDialogComponent(
         viewModel = viewModel,
+        rememberDatePickerState = rememberDatePickerState,
     )
 }
 
@@ -23,12 +27,16 @@ fun DatePickerComponent(
 @Composable
 fun Material3DatePickerDialogComponent(
     viewModel: TodoEntryViewModel,
+    rememberDatePickerState: DatePickerState,
     modifier: Modifier = Modifier,
 ) {
     val closePicker = { viewModel.setShowDatePicker(false) }
     val showTimePicker = { viewModel.setShowTimePicker(true) }
     val datePickerStateSet = { viewModel.updateIsInputDatePickerState(true) }
-    val datePickerState = viewModel.datePickerState
+    fun updateDatePickerState(selectedDateMillis: Long?) =
+        viewModel.updateDatePickerState(selectedDateMillis)
+
+
     DatePickerDialog(
         onDismissRequest = {
             closePicker()
@@ -37,8 +45,8 @@ fun Material3DatePickerDialogComponent(
             Row {
                 TextButton(
                     onClick = {
+                        updateDatePickerState(rememberDatePickerState.selectedDateMillis)
                         datePickerStateSet()
-                        datePickerState.setSelection(datePickerState.selectedDateMillis)
                         closePicker()
                     },
                 ) {
@@ -46,10 +54,10 @@ fun Material3DatePickerDialogComponent(
                 }
                 TextButton(
                     onClick = {
-                        datePickerStateSet()
-                        datePickerState.setSelection(datePickerState.selectedDateMillis)
-                        closePicker()
+                        updateDatePickerState(rememberDatePickerState.selectedDateMillis)
                         showTimePicker()
+                        closePicker()
+                        datePickerStateSet()
                     },
                 ) {
                     Text(text = "set time")
@@ -67,6 +75,6 @@ fun Material3DatePickerDialogComponent(
         },
         modifier = modifier,
     ) {
-        DatePicker(state = datePickerState)
+        DatePicker(state = rememberDatePickerState)
     }
 }

--- a/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryScreen.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryScreen.kt
@@ -28,7 +28,6 @@ import com.example.todoAppJpc.R
 import com.example.todoAppJpc.ui.components.DatePickerComponent
 import com.example.todoAppJpc.ui.components.TimePickerComponent
 
-
 @Composable
 fun TodoEntryBody(
     viewModel: TodoEntryViewModel = hiltViewModel(),

--- a/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryScreen.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.InputChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -99,10 +100,13 @@ fun TodoInputForm(
     modifier: Modifier = Modifier,
     onValueChange: (TodoState) -> Unit = {},
 ) {
+    val rememberDatePickerState = rememberDatePickerState()
     Column(
         modifier = modifier,
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
+        val isInputDeadlineState =
+            viewModel.isInputTimePickerState || viewModel.isInputDatePickerState
         TextField(
             value = todoState.title,
             onValueChange = { onValueChange(todoState.copy(title = it)) },
@@ -119,13 +123,18 @@ fun TodoInputForm(
                 singleLine = false,
             )
         }
-        if (viewModel.getIsInputDeadlineState) {
+        if (isInputDeadlineState) {
             InputChip(
-                label = { Text("${viewModel.getDeadlineUiState()}") },
+                label = { Text(viewModel.getDeadlineUiState()) },
                 onClick = { },
                 selected = false,
                 trailingIcon = {
-                    IconButton(onClick = {}) {
+                    IconButton(onClick = {
+                        viewModel.updateIsInputTimePickerState(false)
+                        viewModel.updateIsInputDatePickerState(false)
+                        viewModel.resetTimePickerState()
+                        viewModel.resetDatePickerState()
+                    }) {
                         Icon(
                             painterResource(id = R.drawable.round_close_24),
                             contentDescription = "Localized description",
@@ -135,7 +144,10 @@ fun TodoInputForm(
             )
         }
         if (viewModel.getShowDatePicker()) {
-            DatePickerComponent(viewModel = viewModel)
+            DatePickerComponent(
+                viewModel = viewModel,
+                rememberDatePickerState = rememberDatePickerState,
+            )
         }
         if (viewModel.getShowTimePicker()) {
             TimePickerComponent(viewModel = viewModel)

--- a/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryViewModel.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/todo/TodoEntryViewModel.kt
@@ -121,7 +121,6 @@ class TodoEntryViewModel @Inject constructor(
         return "$dateUiState $timeUiState"
     }
 
-
     // ---------------- [showDatePicker] ----------------
     private var _showDatePicker by savedStateHandle.saveable {
         mutableStateOf(false)

--- a/app/src/main/java/com/example/todoAppJpc/utils/DeadlineState.kt
+++ b/app/src/main/java/com/example/todoAppJpc/utils/DeadlineState.kt
@@ -5,10 +5,7 @@ import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.DisplayMode
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.TimePickerState
-import java.text.SimpleDateFormat
 import java.time.Instant
-import java.util.Calendar
-import java.util.Locale
 
 data class DeadlineUiState
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,34 +39,10 @@ data class IsInputDeadlineState(
     var isInputDatePickerState: Boolean = false,
 )
 
-fun DeadlineUiState.updateIsInputTimePickerState(isInputState: Boolean) {
-    isInputDeadlineState.isInputTimePickerState = isInputState
+fun IsInputDeadlineState.updateIsInputTimePickerState(isInputState: Boolean) {
+    isInputTimePickerState = isInputState
 }
 
-fun DeadlineUiState.updateIsInputDatePickerState(isInputState: Boolean) {
-    isInputDeadlineState.isInputDatePickerState = isInputState
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-fun DeadlineUiState.getDeadlineUiState(): String {
-    val userLocale = Locale.getDefault()
-    val cal = Calendar.getInstance()
-
-    val timeFormatter = SimpleDateFormat("HH:mm", userLocale)
-    val timeState = deadlineState.timePickerState
-    cal.set(Calendar.HOUR_OF_DAY, timeState.hour)
-    cal.set(Calendar.MINUTE, timeState.minute)
-    cal.isLenient = false
-    val timeUiState =
-        if (isInputDeadlineState.isInputTimePickerState) timeFormatter.format(cal.time) else ""
-
-    val dateFormatter = SimpleDateFormat("MM/dd(EEE)", userLocale)
-    val dateState = deadlineState.datePickerState
-    cal.apply {
-        timeInMillis = dateState.selectedDateMillis!!
-    }
-    val dateUiState =
-        if (isInputDeadlineState.isInputDatePickerState) dateFormatter.format(cal.time) else ""
-
-    return "$dateUiState $timeUiState"
+fun IsInputDeadlineState.updateIsInputDatePickerState(isInputState: Boolean) {
+    isInputDatePickerState = isInputState
 }


### PR DESCRIPTION
主だって変更された部分
- TodoEntryViewModel
- TodoEntryScreen
- DeadlineState
- DatePicker
- TimePicker

大まかな変更内容としてDeadlineStaetで定義していた関数をmutableStateに反応させるためにViewModel側で実装するように変更した。重要なポイントだったのが、ViewModelで値を変更するタイミングと参照するプロパティで、値の変更をScreenに反応させるためにはmutableStateにする必要があったが、参照している値がDeadlineStateによってぐちゃぐちゃになっていた。また、値参照のタイミングもヌルポになるような設計だったため、その辺をとりあえず動く状態まで戻した。

### 残り対応する必要があるもの
- null対応を出来合いのエルビス演算子で行ってたので、そこをコルーチン処理かなんかでawaitする