### PR TITLE
Fix data picker and time picker

### DIFF
--- a/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/components/DatePicker.kt
@@ -3,77 +3,62 @@ package com.example.todoAppJpc.ui.components
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.DatePickerState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.example.todoAppJpc.utils.deadline.DeadlineUiState
+import com.example.todoAppJpc.utils.deadline.viewModel.DeadlinePickerViewModel
 import kotlinx.coroutines.async
+
+//@OptIn(ExperimentalMaterial3Api::class)
+//@Composable
+//fun DatePickerComponent(
+//
+//) {
+//    Material3DatePickerDialogComponent(
+//        deadlineUiState = deadlineUiState,
+//        updateDeadlineUiViewState = updateDeadlineUiViewState,
+//        showDatePickerMutableState = showDatePickerMutableState,
+//        showTimePickerMutableState = showTimePickerMutableState,
+//        rememberDatePickerState = rememberDatePickerState,
+//    )
+//}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerComponent(
-    deadlineUiState: DeadlineUiState,
-    showDatePickerMutableState: MutableState<Boolean>,
-    showTimePickerMutableState: MutableState<Boolean>,
-    updateDeadlineUiViewState: suspend () -> Unit,
-    rememberDatePickerState: DatePickerState = rememberDatePickerState(),
-) {
-    Material3DatePickerDialogComponent(
-        deadlineUiState = deadlineUiState,
-        updateDeadlineUiViewState = updateDeadlineUiViewState,
-        showDatePickerMutableState = showDatePickerMutableState,
-        showTimePickerMutableState = showTimePickerMutableState,
-        rememberDatePickerState = rememberDatePickerState,
-    )
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-fun Material3DatePickerDialogComponent(
-    deadlineUiState: DeadlineUiState,
-    updateDeadlineUiViewState: suspend () -> Unit,
-    rememberDatePickerState: DatePickerState,
-    showDatePickerMutableState: MutableState<Boolean>,
-    showTimePickerMutableState: MutableState<Boolean>,
-    modifier: Modifier = Modifier,
+    title: String = "Set Date",
+    deadlinePickerViewModel: DeadlinePickerViewModel,
+    setChipView: suspend () -> Unit = {},
+    modifier: Modifier
 ) {
     val scope = rememberCoroutineScope()
-    var showDatePickerState by showDatePickerMutableState
-    var showTimePickerState by showTimePickerMutableState
-    val closePicker = { showDatePickerState = false }
-    val showTimePicker = { showTimePickerState = true }
+    val timePickerViewModel = deadlinePickerViewModel.timePickerViewModel
+    val datePickerViewModel = deadlinePickerViewModel.datePickerViewModel
+    var showDatePickerState = datePickerViewModel.showDatePicker
+    var showTimePickerState = timePickerViewModel.showTimePicker
+    val hideDatePicker = { datePickerViewModel.setShowDatePicker(false) }
+    val showTimePicker = { timePickerViewModel.setShowTimePicker(true) }
+    val datePickerState = datePickerViewModel.datePickerState
     val datePickerStateSet = {
         val result = scope.async {
-            updateDeadlineUiViewState()
+            setChipView()
         }
         result.onAwait
-        deadlineUiState.updateIsInputDatePickerState(true)
-    }
-
-    val updateDatePickerState: (selectedDateMillis: Long?) -> Unit = { selectedDateMillis ->
-        scope.async {
-            deadlineUiState.updateDatePickerState(selectedDateMillis)
-        }.onAwait
     }
 
     DatePickerDialog(
         onDismissRequest = {
-            closePicker()
+            hideDatePicker()
         },
         confirmButton = {
             Row {
                 TextButton(
                     onClick = {
                         datePickerStateSet()
-                        closePicker()
+                        hideDatePicker()
                     },
                 ) {
                     Text(text = "OK")
@@ -81,7 +66,7 @@ fun Material3DatePickerDialogComponent(
                 TextButton(
                     onClick = {
                         showTimePicker()
-                        closePicker()
+                        hideDatePicker()
                         datePickerStateSet()
                     },
                 ) {
@@ -92,7 +77,7 @@ fun Material3DatePickerDialogComponent(
         dismissButton = {
             TextButton(
                 onClick = {
-                    closePicker()
+                    hideDatePicker()
                 },
             ) {
                 Text(text = "CANCEL")
@@ -100,6 +85,6 @@ fun Material3DatePickerDialogComponent(
         },
         modifier = modifier,
     ) {
-        DatePicker(state = rememberDatePickerState)
+        DatePicker(state = datePickerState)
     }
 }

--- a/app/src/main/java/com/example/todoAppJpc/ui/components/TimePicker.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/components/TimePicker.kt
@@ -29,15 +29,16 @@ import kotlinx.coroutines.async
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TimePickerComponent(
-    title: String = "Select Time",
+    title: String = "Set Time",
     deadlinePickerViewModel: DeadlinePickerViewModel,
+    setChipView: suspend () -> Unit,
     toggle: @Composable () -> Unit = {},
 ) {
+    val scope = rememberCoroutineScope()
     val timePickerViewModel = deadlinePickerViewModel.timePickerViewModel
     val datePickerViewModel = deadlinePickerViewModel.datePickerViewModel
-    val scope = rememberCoroutineScope()
     val showDatePickerState = datePickerViewModel.showDatePicker
-    val closePicker = { timePickerViewModel.setShowTimePicker(false) }
+    val hideTimePicker = { timePickerViewModel.setShowTimePicker(false) }
     val showDatePicker = { datePickerViewModel.setShowDatePicker(true) }
     val timePickerState = timePickerViewModel.timePickerState
 
@@ -48,15 +49,12 @@ fun TimePickerComponent(
              * Chipの値表示はEntryにもEditにもいるのでdeadlineViewModelに入れる
              * Todoの値の更新はdeadlineの範囲を超えているんで、各ViewModelで適宜入れる
              */
-//            updateDeadlineUiViewState()
-
+            setChipView()
         }
         result.onAwait
-        // 値が入力されたかどうかも、初期値によって見分けるようにする
-//        deadlineUiState.updateIsInputTimePickerState(true)
     }
     Dialog(
-        onDismissRequest = closePicker,
+        onDismissRequest = hideTimePicker,
         properties = DialogProperties(
             usePlatformDefaultWidth = false,
         ),
@@ -92,17 +90,17 @@ fun TimePickerComponent(
                 ) {
                     Spacer(modifier = Modifier.weight(1f))
                     TextButton(
-                        onClick = closePicker,
+                        onClick = hideTimePicker,
                     ) { Text("Cancel") }
                     TextButton(
                         onClick = {
-                            closePicker()
+                            hideTimePicker()
                             timePickerStateSet()
                         },
                     ) { Text("OK") }
                     TextButton(
                         onClick = {
-                            closePicker()
+                            hideTimePicker()
                             timePickerStateSet()
                             showDatePicker()
                         },

--- a/app/src/main/java/com/example/todoAppJpc/ui/screen/TodoEntryScreen.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/screen/TodoEntryScreen.kt
@@ -165,19 +165,20 @@ fun TodoInputForm(
             )
         }
 
+        // Todo: setChipViewを完成させる
         if (showDatePickerState) {
             DatePickerComponent(
-                deadlineUiState = deadlineUiState, // Todo: TimePickerComponentと同様の実装に変更する
-                showDatePickerMutableState = showDatePickerMutableState,
-                showTimePickerMutableState = showDatePickerMutableState,
-                rememberDatePickerState = rememberDatePickerState,
-                updateDeadlineUiViewState = { viewModel.updateDeadlineUiViewState() },
+                deadlinePickerViewModel = deadlinePickerViewModel,
+                setChipView = {},
+                modifier = modifier,
             )
         }
         if (showTimePickerState) {
             TimePickerComponent(
-                deadlinePickerViewModel = deadlinePickerViewModel
-            )
+                deadlinePickerViewModel = deadlinePickerViewModel,
+                setChipView = {},
+
+                )
         }
     }
 }


### PR DESCRIPTION
addLiveDataのブランチを切ったけど、作業の流れで結局PickerComponentの実装を変更してしまった
意図としては違うけれど、元ブランチとの命名の差がわからない状態になってしまった。
|ブランチ名|説明|
|---|---|
|fixDeadlinePicker | Picker系統の処理を理想系に完成させる|
|fixData(dateのタイポ)PickerAndTimePicker | deadlinePickerViewModelに対応させる実装変更|
|addLiveData | liveDataによる実装変更|

