### PR TITLE
fix editとentryでdeadlinePickerStateが共有されるバグ

### DIFF
--- a/app/src/main/java/com/example/todoAppJpc/di/DeadlinePickerViewModelProvider.kt
+++ b/app/src/main/java/com/example/todoAppJpc/di/DeadlinePickerViewModelProvider.kt
@@ -8,22 +8,18 @@ import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
 
 @InstallIn(SingletonComponent::class)
 @Module
 class DeadlinePickerViewModelProvider {
     @Provides
-    @Singleton
     fun datePickerViewModelProvider(): DatePickerViewModel {
         return DatePickerViewModelImpl()
     }
 
     @Provides
-    @Singleton
     fun timePickerViewModelProvider(): TimePickerViewModel {
         return TimePickerViewModelImpl()
     }
-
 
 }

--- a/app/src/main/java/com/example/todoAppJpc/ui/viewmodel/TodoEditViewModel.kt
+++ b/app/src/main/java/com/example/todoAppJpc/ui/viewmodel/TodoEditViewModel.kt
@@ -105,7 +105,7 @@ class TodoEditViewModel @Inject constructor(
             withContext(Dispatchers.IO) {
                 todoRepository.updateTodo(todoUiState.todoState.toTodo())
             }
-            resetTodoState()
+//            resetTodoState()
         }
     }
 


### PR DESCRIPTION
editとentryでdeadlinePickerStateが共有されるバグを解消

原因は、di部分で@Singletonアノテーションをつけてしまっており、ViewModelごとのインスタンスの生成が行われなかったことだった。
基本的に、ViewModelにSingletonはつけないらしい。